### PR TITLE
feature: Add Promise trait, a pair implementation, and generic errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "promise_out"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "promiseOut version for rust"
 authors = ["waterbang <water_bang@163.com>"]
@@ -8,5 +8,5 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -11,29 +11,34 @@ promiseOut的rust版本
 ```rust
 #[test]
 fn test_promise_out_resolve() {
-    let op: PromiseOut<String> = PromiseOut::default();
-    let op_a  = op.clone();
-    let task1 = thread::spawn(move || block_on(async {
-        println!("我等到了{:?}",  op_a.await);
-    }));
-    let task2 = thread::spawn(move || block_on(async {
-        println!("我发送了了{:?}", op.resolve(String::from("🍓")));
-    }));
+    let (op, op_a) = Producer::<String, ()>::new();
+    let task1 = thread::spawn(move || {
+        block_on(async {
+            println!("我等到了{:?}", op_a.await);
+        })
+    });
+    let task2 = thread::spawn(move || {
+        block_on(async {
+            println!("我发送了了{:?}", op.resolve(String::from("🍓")));
+        })
+    });
     task1.join().expect("The task1 thread has panicked");
     task2.join().expect("The task2 thread has panicked");
 }
 
 #[test]
 fn test_promise_out_reject() {
-    let op: PromiseOut<String> = PromiseOut::default();
-    let a = op.clone();
-    let task1 = thread::spawn(|| block_on(async {
-        println!("我等到了{:?}", a.await);
-    }));
-    let b = op.clone();
-    let task2 = thread::spawn(|| block_on(async {
-        println!("我发送了了{:?}", b.reject(String::from("reject!!")));
-    }));
+    let (a, b) = Producer::<String, String>::new();
+    let task1 = thread::spawn(|| {
+        block_on(async {
+            println!("我等到了{:?}", b.await);
+        })
+    });
+    let task2 = thread::spawn(|| {
+        block_on(async {
+            println!("我发送了了{:?}", a.reject(String::from("reject!!")));
+        })
+    });
     task1.join().expect("The task1 thread has panicked");
     task2.join().expect("The task2 thread has panicked");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,22 @@
-use std::fmt::Debug;
-use std::sync::{Arc, Mutex};
-use std::task::Waker;
-use std::{future::Future, task::Poll};
-pub mod promise_out;
-pub mod pair;
+use std::future::Future;
 
-///promise
+/// An Async Promise
 ///
-/// # Examples
+/// A promise can be resolved or rejected, either consumes the promise. The
+/// consumer is a future that can be `.await`ed.
 ///
 /// ```
-/// use promise_out::{Promise, Producer};
-/// let (producer, consumer) = Producer::<String, String>::new();
+/// use promise_out::{Promise, pair::Producer};
+/// use futures::executor::block_on;
+/// use std::thread;
+/// let (promise, consumer) = Producer::<String, String>::new();
+///
+/// let task1 = thread::spawn(move || block_on(async {
+///     println!("Received {:?}",  consumer.await);
+/// }));
+/// promise.resolve("Hi".into());
+/// task1.join().expect("The task1 thread has panicked.");
 /// ```
-#[derive(Debug)]
-pub struct Producer<T, E> {
-    promise: Arc<Mutex<Inner<T, E>>>,
-}
-
-#[derive(Clone)]
-pub struct Consumer<T, E> {
-    promise: Arc<Mutex<Inner<T, E>>>,
-}
-
-#[derive(Debug)]
-struct Inner<T, E> {
-    value: Option<Arc<Result<T, E>>>,
-    waker: Vec<Waker>, // This was failing the two promise when only one waker
-                       // was kept. Even though many docs insist you only need
-                       // to wake the last waker. I don't get it.
-                       // https://rust-lang.github.io/async-book/02_execution/03_wakeups.html
-}
-
 pub trait Promise {
     type Output;
     type Error;
@@ -42,169 +27,6 @@ pub trait Promise {
     fn new() -> (Self, Self::Waiter) where Self: Sized;
 }
 
-impl<T, E> Promise for Producer<T,E> {
-    type Output = T;
-    type Error = E;
-    type Waiter = Consumer<T,E>;
-    #[allow(dead_code)]
-    ///promiseOut.resolve
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use promise_out::{Promise, Producer};
-    /// use futures::executor::block_on;
-    /// use std::thread;
-    /// let (op, op_a) = Producer::<String, ()>::new();
-    /// let task1 = thread::spawn(move || block_on(async {
-    ///     println!("我等到了{:?}",  op_a.await);
-    /// }));
-    /// let task2 = thread::spawn(move || block_on(async {
-    ///     println!("我发送了{:?}", op.resolve(String::from("🍓")));
-    /// }));
-    /// task1.join().expect("The task1 thread has panicked");
-    /// task2.join().expect("The task2 thread has panicked");
-    /// ```
-    fn resolve(self, value: T) {
-        let mut promise = self.promise.lock().unwrap();
-        promise.value = Some(Arc::new(Ok(value)));
-        for waker in promise.waker.drain(..) {
-            waker.wake()
-        }
-    }
-    ///promiseOut.reject
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use promise_out::{Promise, Producer};
-    /// use futures::executor::block_on;
-    /// use std::thread;
-    /// let (op, op_a) = Producer::<(), String>::new();
-    /// let task1 = thread::spawn(move || block_on(async {
-    ///     println!("我等到了{:?}",  op_a.await);
-    /// }));
-    /// let task2 = thread::spawn(move || block_on(async {
-    ///     println!("我发送了{:?}", op.reject(String::from("💥")));
-    /// }));
-    /// task1.join().expect("The task1 thread has panicked");
-    /// task2.join().expect("The task2 thread has panicked");
-    /// ```
-    #[allow(dead_code)]
-    fn reject(self, err: E) {
-        let mut promise = self.promise.lock().unwrap();
-        promise.value = Some(Arc::new(Err(err)));
-        for waker in promise.waker.drain(..) {
-            waker.wake()
-        }
-    }
-
-    /// promise.new
-    ///
-    /// This is a slight fib because we're not implementing Clone, and we aren't
-    /// doing that because we're not returning Self. We're returning a
-    /// Consumer<T, E> which you can wait on.
-    fn new() -> (Self, Self::Waiter) {
-        let producer = Self {
-                            promise: Arc::new(Mutex::new(Inner {
-                                value: None,
-                                waker: vec![],
-                            })),
-                        };
-        let consumer = Consumer { promise: producer.promise.clone() };
-        (producer, consumer)
-    }
-
-}
-
-impl<T, E> Future for Consumer<T, E> {
-    type Output = Arc<Result<T, E>>;
-
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        let mut promise = self.promise.lock().unwrap();
-        match promise.value {
-            Some(ref value) => Poll::Ready(value.clone()),
-            None => {
-                promise.waker.push(cx.waker().clone());
-                Poll::Pending
-            }
-        }
-    }
-}
-
-#[allow(unused_imports)]
-use futures::executor::block_on;
-#[allow(unused_imports)]
-use std::thread;
-
-#[allow(unused_must_use)]
-#[test]
-fn test_promise_out_resolve() {
-    let (op, op_a) = Producer::<String, ()>::new();
-    let task1 = thread::spawn(move || {
-        block_on(async {
-            println!("我等到了{:?}", op_a.await);
-        })
-    });
-    let task2 = thread::spawn(move || {
-        block_on(async {
-            println!("我发送了了{:?}", op.resolve(String::from("🍓")));
-        })
-    });
-    task1.join().expect("The task1 thread has panicked");
-    task2.join().expect("The task2 thread has panicked");
-}
-
-#[allow(unused_must_use)]
-#[test]
-fn test_promise_resolve_twice() {
-    let (a, _b) = Producer::<String, ()>::new();
-    a.resolve("hi".into());
-    // Not possible. a is consumed.
-    // a.resolve("hi".into());
-}
-
-#[allow(unused_must_use)]
-#[test]
-fn test_two_promises_out_resolve() {
-    let (op, op_a) = Producer::<String, ()>::new();
-    let op_b = op_a.clone();
-    let task1 = thread::spawn(move || {
-        block_on(async {
-            println!("我等到了{:?} task1", op_a.await);
-        })
-    });
-    let task2 = thread::spawn(move || {
-        block_on(async {
-            println!("我等到了{:?} task2", op_b.await);
-        })
-    });
-    let task3 = thread::spawn(move || {
-        block_on(async {
-            println!("我发送了了{:?} task3", op.resolve(String::from("🍓")));
-        })
-    });
-    task1.join().expect("The task1 thread has panicked");
-    task2.join().expect("The task2 thread has panicked");
-    task3.join().expect("The task3 thread has panicked");
-}
-
-#[test]
-fn test_promise_out_reject() {
-    let (a, b) = Producer::<String, String>::new();
-    let task1 = thread::spawn(|| {
-        block_on(async {
-            println!("我等到了{:?}", b.await);
-        })
-    });
-    let task2 = thread::spawn(|| {
-        block_on(async {
-            println!("我发送了了{:?}", a.reject(String::from("reject!!")));
-        })
-    });
-    task1.join().expect("The task1 thread has panicked");
-    task2.join().expect("The task2 thread has panicked");
-}
+pub mod promise_out;
+pub mod pair;
+pub mod poly;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,12 @@ pub mod promise_out;
 /// let op: PromiseOut<String,String> = PromiseOut::default();
 /// ```
 #[derive(Clone, Debug)]
-pub struct PromiseOut<T,E> {
-    promise: Arc<Mutex<Promise<T,E>>>,
+pub struct PromiseOut<T, E> {
+    promise: Arc<Mutex<Promise<T, E>>>,
 }
 
 #[derive(Clone, Debug)]
-pub struct Promise<T,E> {
+pub struct Promise<T, E> {
     value: Option<Arc<Result<T, E>>>,
     waker: Vec<Waker>, // This was failing the two promise when only one waker
                        // was kept. Even though many docs insist you only need
@@ -26,10 +26,10 @@ pub struct Promise<T,E> {
                        // https://rust-lang.github.io/async-book/02_execution/03_wakeups.html
 }
 
-impl<T,E> PromiseOut<T,E>
+impl<T, E> PromiseOut<T, E>
 where
     T: Clone,
-    E: Clone
+    E: Clone,
 {
     #[allow(dead_code)]
     ///promiseOut.resolve
@@ -87,7 +87,7 @@ where
     }
 }
 
-impl<T,E> Default for PromiseOut<T,E> {
+impl<T, E> Default for PromiseOut<T, E> {
     fn default() -> Self {
         Self {
             promise: Arc::new(Mutex::new(Promise {
@@ -98,10 +98,7 @@ impl<T,E> Default for PromiseOut<T,E> {
     }
 }
 
-impl<T,E> Future for PromiseOut<T,E>
-where
-    T: Debug + Clone + 'static,
-{
+impl<T, E> Future for PromiseOut<T, E> {
     type Output = Arc<Result<T, E>>;
 
     fn poll(
@@ -110,10 +107,11 @@ where
     ) -> std::task::Poll<Self::Output> {
         let mut promise = self.promise.lock().unwrap();
         match promise.value {
-          Some(ref value) =>
-                    Poll::Ready(value.clone()),
-          None => { promise.waker.push(cx.waker().clone());
-                    Poll::Pending },
+            Some(ref value) => Poll::Ready(value.clone()),
+            None => {
+                promise.waker.push(cx.waker().clone());
+                Poll::Pending
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,16 @@ fn test_promise_out_resolve() {
 
 #[allow(unused_must_use)]
 #[test]
+fn test_promise_resolve_twice() {
+    let a: Promise<String, String> = Promise::default();
+    let b = a.clone();
+    a.resolve("hi".into());
+    // Not possible. a is consumed.
+    // a.resolve("hi".into());
+}
+
+#[allow(unused_must_use)]
+#[test]
 fn test_two_promises_out_resolve() {
     let op: Promise<String, String> = Promise::default();
     let op_a = op.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ pub mod pair;
 /// # Examples
 ///
 /// ```
-/// use promise_out::Producer;
-/// let op: Producer<String,String> = Producer::default();
+/// use promise_out::{Promise, Producer};
+/// let (producer, consumer) = Producer::<String, String>::new();
 /// ```
 #[derive(Debug)]
 pub struct Producer<T, E> {
@@ -105,22 +105,16 @@ impl<T, E> Promise for Producer<T,E> {
     /// doing that because we're not returning Self. We're returning a
     /// Consumer<T, E> which you can wait on.
     fn new() -> (Self, Self::Waiter) {
-        let producer = Producer::default();
+        let producer = Self {
+                            promise: Arc::new(Mutex::new(Inner {
+                                value: None,
+                                waker: vec![],
+                            })),
+                        };
         let consumer = Consumer { promise: producer.promise.clone() };
         (producer, consumer)
     }
 
-}
-
-impl<T, E> Default for Producer<T, E> {
-    fn default() -> Self {
-        Self {
-            promise: Arc::new(Mutex::new(Inner {
-                value: None,
-                waker: vec![],
-            })),
-        }
-    }
 }
 
 impl<T, E> Future for Consumer<T, E> {

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -122,10 +122,14 @@ impl<T, E> Future for Consumer<T, E> {
     }
 }
 
+#[cfg(test)]
+mod tests {
 #[allow(unused_imports)]
 use futures::executor::block_on;
 #[allow(unused_imports)]
 use std::thread;
+use super::Producer;
+use crate::Promise;
 
 #[allow(unused_must_use)]
 #[test]
@@ -160,4 +164,5 @@ fn test_promise_out_reject() {
     });
     task1.join().expect("The task1 thread has panicked");
     task2.join().expect("The task2 thread has panicked");
+}
 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -9,7 +9,7 @@ use crate::Promise;
 /// # Examples
 ///
 /// ```
-/// use promise_out::{Promise, pair::Producer};
+/// use promise_out::{Promise, poly::Producer};
 /// use futures::executor::block_on;
 /// use std::thread;
 /// let (promise, consumer) = Producer::<String, String>::new();
@@ -137,10 +137,14 @@ impl<T, E> Future for Consumer<T, E> {
     }
 }
 
+#[cfg(test)]
+mod tests {
 #[allow(unused_imports)]
 use futures::executor::block_on;
 #[allow(unused_imports)]
 use std::thread;
+use super::Producer;
+use crate::Promise;
 
 #[allow(unused_must_use)]
 #[test]
@@ -158,15 +162,6 @@ fn test_promise_out_resolve() {
     });
     task1.join().expect("The task1 thread has panicked");
     task2.join().expect("The task2 thread has panicked");
-}
-
-#[allow(unused_must_use)]
-#[test]
-fn test_promise_resolve_twice() {
-    let (a, _b) = Producer::<String, ()>::new();
-    a.resolve("hi".into());
-    // Not possible. a is consumed.
-    // a.resolve("hi".into());
 }
 
 #[allow(unused_must_use)]
@@ -209,4 +204,15 @@ fn test_promise_out_reject() {
     });
     task1.join().expect("The task1 thread has panicked");
     task2.join().expect("The task2 thread has panicked");
+}
+
+#[allow(unused_must_use)]
+#[test]
+fn test_promise_resolve_twice() {
+    let (a, _b) = Producer::<String, ()>::new();
+    a.resolve("hi".into());
+    // Not possible. a is consumed.
+    // a.resolve("hi".into());
+}
+
 }


### PR DESCRIPTION
Thank you for the promise_out crate. It's been very helpful. 

I needed to permit a different error type, and then I got swept up and continued refactoring. I added a `Promise` trait and separated out two implementations. I also separated the promise producer and consumer. I feel weird about promises being able to resolved by anyone. Your original implementation I placed under `promise_out::poly::{Producer, Consumer}` and a new implementation that doesn't allow the promise's consumer to be cloned I placed under `promise_out::pair::{Producer, Consumer}`.

I also moved the futures dependency to a dev-dependency. All tests have passed. I copied and modified tests from poly for pair.

These are admittedly big changes. I understand if you do not want to accept them. I would publish them under a different crate name with attribution to you if you don't want them.